### PR TITLE
Accept slashes in parameter values

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,10 @@
  * qdtext        = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
  * obs-text      = %x80-FF
  * quoted-pair   = "\" ( HTAB / SP / VCHAR / obs-text )
+ *
+ * Additionally, we accept "/" in parameter values.
  */
-var paramRegExp = /; *([!#$%&'\*\+\-\.\^_`\|~0-9A-Za-z]+) *= *("(?:[\u000b\u0020\u0021\u0023-\u005b\u005d-\u007e\u0080-\u00ff]|\\[\u000b\u0020-\u00ff])*"|[!#$%&'\*\+\-\.\^_`\|~0-9A-Za-z]+) */g
+var paramRegExp = /; *([!#$%&'\*\+\-\.\^_`\|~0-9A-Za-z]+) *= *("(?:[\u000b\u0020\u0021\u0023-\u005b\u005d-\u007e\u0080-\u00ff]|\\[\u000b\u0020-\u00ff])*"|[!#$%&'\*\+\-\.\^_`\|~\/0-9A-Za-z]+) */g
 var textRegExp = /^[\u000b\u0020-\u007e\u0080-\u00ff]+$/
 var tokenRegExp = /^[!#$%&'\*\+\-\.\^_`\|~0-9A-Za-z]+$/
 


### PR DESCRIPTION
While the RFC is excluding slashes from tokens and thus parameter values, some existing content-type values do contain them, and existing content-type parsers are generally lenient when encountering them.