### PR TITLE
Update typeRegExp docstring to reflect implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ var qescRegExp = /\\([\u000b\u0020-\u00ff])/g
 var quoteRegExp = /([\\"])/g
 
 /**
- * RegExp to match type in RFC 6838
+ * RegExp to match type in RFC 7231 sec 3.1.1.1
  *
  * media-type = type "/" subtype
  * type       = token


### PR DESCRIPTION
typeRegExp docstring improperly states conformance with RFC 6838 instead of what the implementation reflects (RFC 7231 sec 3.1.1.1)