### PR TITLE
FIX: When property value contains forwardslash

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@
  * obs-text      = %x80-FF
  * quoted-pair   = "\" ( HTAB / SP / VCHAR / obs-text )
  */
-var PARAM_REGEXP = /; *([!#$%&'*+.^_`|~0-9A-Za-z-]+) *= *("(?:[\u000b\u0020\u0021\u0023-\u005b\u005d-\u007e\u0080-\u00ff]|\\[\u000b\u0020-\u00ff])*"|[!#$%&'*+.^_`|~0-9A-Za-z-]+) */g
+var PARAM_REGEXP = /; *([!#$%&'*+.^_`|~0-9A-Za-z-]+) *= *("(?:[\u000b\u0020\u0021\u0023-\u005b\u005d-\u007e\u0080-\u00ff]|\\[\u000b\u0020-\u00ff])*"|[!#$%&'*+.^_`|/~0-9A-Za-z-]+) */g
 var TEXT_REGEXP = /^[\u000b\u0020-\u007e\u0080-\u00ff]+$/
 var TOKEN_REGEXP = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/
 

--- a/test/contentType_parse.js
+++ b/test/contentType_parse.js
@@ -88,7 +88,7 @@ describe('contentType.parse(string)', function () {
     })
   })
 
-  it('should work with when parameter value contains forwardslash', function() {
+  it('should work with when parameter value contains forwardslash', function () {
     var type = contentType.parse('multipart/form-data; boundary=UUKn-QYhlhZR4UhMuBO/6SvI.FBLAreiv1ZS9i6v_1u3d5dF8_e_i_HlvL_dZCGD_zBKp')
     assert.equal(type.type, 'multipart/form-data')
     assert.equal(type.parameters.boundary, 'UUKn-QYhlhZR4UhMuBO/6SvI.FBLAreiv1ZS9i6v_1u3d5dF8_e_i_HlvL_dZCGD_zBKp')

--- a/test/contentType_parse.js
+++ b/test/contentType_parse.js
@@ -88,6 +88,12 @@ describe('contentType.parse(string)', function () {
     })
   })
 
+  it('should work with when parameter value contains forwardslash', function() {
+    var type = contentType.parse('multipart/form-data; boundary=UUKn-QYhlhZR4UhMuBO/6SvI.FBLAreiv1ZS9i6v_1u3d5dF8_e_i_HlvL_dZCGD_zBKp')
+    assert.equal(type.type, 'multipart/form-data')
+    assert.equal(type.parameters.boundary, 'UUKn-QYhlhZR4UhMuBO/6SvI.FBLAreiv1ZS9i6v_1u3d5dF8_e_i_HlvL_dZCGD_zBKp')
+  })
+
   invalidTypes.forEach(function (type) {
     it('should throw on invalid media type ' + type, function () {
       assert.throws(contentType.parse.bind(null, type), /invalid media type/)


### PR DESCRIPTION
We encountered edge case when using FormData on iOS inside React Native
would generate boundary value that would include forward slashes.

I checked RFC7231, section 3.1.1.1. (Media Type) and there is nothing
specified regarding property value format. Since there is obviously case
when such property is generated I believe that it should be supported
(especially since there are other libraries that depend on this module
used for server side parsing).

I added test covering case we encountered.
I didn't touch versioning but if you want I can create minor version bump.