### PR TITLE
Fix ci GH action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           npm-i: mocha@5.2.0 nyc@11.9.0
 
         - name: Node.js 6.x
-          node-version: "6.16"
+          node-version: "6.17"
           npm-i: mocha@6.2.3 nyc@14.1.1
 
         - name: Node.js 7.x
@@ -83,11 +83,11 @@ jobs:
 
         - name: Node.js 8.x
           node-version: "8.17"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 9.x
           node-version: "9.11"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 10.x
           node-version: "10.24"
@@ -99,30 +99,27 @@ jobs:
 
         - name: Node.js 12.x
           node-version: "12.22"
-          npm-i: mocha@9.2.2
 
         - name: Node.js 13.x
           node-version: "13.14"
-          npm-i: mocha@9.2.2
 
         - name: Node.js 14.x
-          node-version: "14.21"
+          node-version: "14.19"
 
         - name: Node.js 15.x
           node-version: "15.14"
 
         - name: Node.js 16.x
-          node-version: "16.19"
+          node-version: "16.13"
 
         - name: Node.js 17.x
-          node-version: "17.9"
+          node-version: "17.4"
 
         - name: Node.js 18.x
-          node-version: "18.13"
+          node-version: "18.20"
 
         - name: Node.js 19.x
-          node-version: "19.5"
-
+          node-version: "19.9"
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         name:
-        - Node.js 0.6
         - Node.js 0.8
         - Node.js 0.10
         - Node.js 0.12
@@ -33,6 +32,8 @@ jobs:
         - Node.js 17.x
         - Node.js 18.x
         - Node.js 19.x
+        - Node.js 20.x
+        - Node.js 21.x
 
         include:
         - name: Node.js 0.6
@@ -120,6 +121,13 @@ jobs:
 
         - name: Node.js 19.x
           node-version: "19.9"
+
+        - name: Node.js 20.x
+          node-version: "20.12"
+
+        - name: Node.js 21.x
+          node-version: "21.7"
+
     steps:
     - uses: actions/checkout@v3
 
@@ -187,14 +195,13 @@ jobs:
         echo "node@$(node -v)"
         echo "npm@$(npm -v)"
         npm -s ls ||:
-        (npm -s ls --depth=0 ||:) | awk -F'[ @]' 'NR>1 && $2 { print $2 "=" $3 }' >> "$GITHUB_OUTPUT"
+        (npm -s ls --depth=0 ||:) | awk -F'[ @]' 'NR>1 && $2 { print "::set-output name=" $2 "::" $3 }'
 
     - name: Run tests
       shell: bash
       run: |
         if npm -ps ls nyc | grep -q nyc; then
           npm run test-ci
-          cp coverage/lcov.info "coverage/${{ matrix.name }}.lcov"
         else
           npm test
         fi


### PR DESCRIPTION
Work done

* [pin nyc version for node 8 & 9](https://github.com/jshttp/content-type/commit/2e30424d340d00c01a9bd805bcbf62cee4bbb8fb)

* [add missing node versions to ci action](https://github.com/jshttp/content-type/commit/9db4b73b6755735e7272923b02d7e8742932a6c1)