### PR TITLE
Replace deep-equal with dequal

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": "jshttp/content-type",
   "devDependencies": {
-    "deep-equal": "1.0.1",
+    "dequal": "2.0.3",
     "eslint": "8.32.0",
     "eslint-config-standard": "15.0.1",
     "eslint-plugin-import": "2.27.5",

--- a/test/contentType_parse.js
+++ b/test/contentType_parse.js
@@ -1,7 +1,7 @@
 
 var assert = require('assert')
 var contentType = require('..')
-var deepEqual = require('deep-equal')
+var deepEqual = require('dequal')
 
 var invalidTypes = [
   ' ',


### PR DESCRIPTION
This PR replaces deep-equal with dequal, an alternative package with 0 dependencies (as opposed to 49: https://npmgraph.js.org/?q=deep-equal).