### PR TITLE
Refactor parser to be lenient on values

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status][ci-image]][ci-url]
 [![Coverage Status][coveralls-image]][coveralls-url]
 
-Create and parse HTTP Content-Type header according to RFC 7231
+Create and parse HTTP Content-Type header.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dist/"
   ],
   "scripts": {
+    "bench": "vitest bench",
     "build": "ts-scripts build",
     "format": "ts-scripts format",
     "lint": "ts-scripts lint",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "http",
     "req",
     "res",
-    "rfc7231"
+    "rfc7231",
+    "rfc9110"
   ],
   "repository": "jshttp/content-type",
   "funding": {

--- a/src/index.bench.ts
+++ b/src/index.bench.ts
@@ -1,0 +1,59 @@
+import { bench, describe } from "vitest";
+import { format, parse } from "./index";
+
+describe("parse", () => {
+  const BASIC_HEADER = "text/html";
+  const PARAMS_HEADER = "application/json; charset=utf-8; foo=bar; version=1";
+  const QUOTED_HEADER =
+    'text/plain; filename="report\\"-2026.csv"; foo=bar; version=1';
+  const OWS_HEADER =
+    "application/json; \t  charset = utf-8 ;\t foo = bar ; version = 1";
+
+  bench("basic", () => {
+    parse(BASIC_HEADER);
+  });
+
+  bench("simple parameters", () => {
+    parse(PARAMS_HEADER);
+  });
+
+  bench("quoted and escaped parameters", () => {
+    parse(QUOTED_HEADER);
+  });
+
+  bench("OWS-heavy parameters", () => {
+    parse(OWS_HEADER);
+  });
+});
+
+describe("format", () => {
+  const BASIC_OBJECT = { type: "text/html" };
+  const PARAMS_OBJECT = {
+    type: "application/json",
+    parameters: {
+      charset: "utf-8",
+      profile: "urn:example:v1",
+      version: "1",
+    },
+  };
+  const QUOTED_OBJECT = {
+    type: "text/plain",
+    parameters: {
+      filename: 'report"-2026.csv',
+      foo: "test=bar",
+      q: "0.9",
+    },
+  };
+
+  bench("basic", () => {
+    format(BASIC_OBJECT);
+  });
+
+  bench("simple parameters", () => {
+    format(PARAMS_OBJECT);
+  });
+
+  bench("quoted and escaped parameters", () => {
+    format(QUOTED_OBJECT);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,15 +137,11 @@ function parseParameters(
           index++;
 
           let value = "";
+          let quoted = false;
           while (index < len) {
             const char = header[index++];
             if (char === '"') {
-              index = skipOWS(header, index, len);
-              if (index < len && header[index] !== ";") {
-                throw new TypeError("unexpected non-separator character");
-              }
-
-              parameters[key] = value;
+              quoted = true;
               break;
             }
 
@@ -157,6 +153,14 @@ function parseParameters(
             value += char;
           }
 
+          if (!quoted) throw new TypeError("unexpected end of input");
+
+          index = skipOWS(header, index, len);
+          if (index < len && header[index] !== ";") {
+            throw new TypeError("unexpected non-separator character");
+          }
+
+          parameters[key] = value;
           break;
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,12 @@ const TEXT_REGEXP = /^[\u000b\u0020-\u007e\u0080-\u00ff]+$/;
 const TOKEN_REGEXP = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 
 /**
- * RegExp to match chars that must be quoted-pair in RFC 7230 sec 3.2.6
+ * RegExp to match chars that must be quoted-pair in RFC 9110 sec 5.6.4
  */
 const QUOTE_REGEXP = /[\\"]/g;
 
 /**
- * RegExp to match type in RFC 7231 sec 3.1.1.1
+ * RegExp to match type in RFC 9110 sec 8.3.1
  *
  * media-type = type "/" subtype
  * type       = token
@@ -140,18 +140,12 @@ function parseParameters(
           while (index < len) {
             const char = header[index++];
             if (char === '"') {
-              let validTrailingOWS = true;
-
-              // Increment to next parameter.
-              while (index < len) {
-                const char = header[index];
-                if (char === ";") break;
-                validTrailingOWS &&= char === " " || char === "\t";
-                index++;
+              index = skipOWS(header, index, len);
+              if (index < len && header[index] !== ";") {
+                throw new TypeError("unexpected non-separator character");
               }
 
-              // Ignore parameters with non-OWS after closing quote as undefined behavior.
-              if (validTrailingOWS) parameters[key] = value;
+              parameters[key] = value;
               break;
             }
 
@@ -181,6 +175,11 @@ function parseParameters(
   return parameters;
 }
 
+/**
+ * Skip optional whitespace (OWS) in an HTTP header value.
+ *
+ * OWS is defined in RFC 9110 sec 5.6.3 as SP (" ") or HTAB ("\t").
+ */
 function skipOWS(header: string, index: number, len: number): number {
   while (index < len) {
     const code = header[index];
@@ -190,6 +189,11 @@ function skipOWS(header: string, index: number, len: number): number {
   return index;
 }
 
+/**
+ * Trim optional whitespace (OWS) from the end of a substring.
+ *
+ * OWS is defined in RFC 9110 sec 5.6.3 as SP (" ") or HTAB ("\t").
+ */
 function trailingOWS(header: string, start: number, end: number): number {
   while (end > start) {
     const code = header[end - 1];

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,38 +4,13 @@
  * MIT Licensed
  */
 
-/**
- * RegExp to match *( ";" parameter ) in RFC 7231 sec 3.1.1.1
- *
- * parameter     = token "=" ( token / quoted-string )
- * token         = 1*tchar
- * tchar         = "!" / "#" / "$" / "%" / "&" / "'" / "*"
- *               / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
- *               / DIGIT / ALPHA
- *               ; any VCHAR, except delimiters
- * quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE
- * qdtext        = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
- * obs-text      = %x80-FF
- * quoted-pair   = "\\" ( HTAB / SP / VCHAR / obs-text )
- */
-const PARAM_REGEXP =
-  /;[\t ]*([!#$%&'*+.^_`|~0-9A-Za-z-]+)[\t ]*=[\t ]*("(?:[\u000b\u0020\u0021\u0023-\u005b\u005d-\u007e\u0080-\u00ff]|\\[\u000b\u0020-\u00ff])*"|[!#$%&'*+.^_`|~0-9A-Za-z-]+)[\t ]*/g;
-
-const TEXT_REGEXP = /^[\u000b\u0020-\u007e\u0080-\u00ff]+$/; // eslint-disable-line no-control-regex
+const TEXT_REGEXP = /^[\u000b\u0020-\u007e\u0080-\u00ff]+$/;
 const TOKEN_REGEXP = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
-
-/**
- * RegExp to match quoted-pair in RFC 7230 sec 3.2.6
- *
- * quoted-pair = "\\" ( HTAB / SP / VCHAR / obs-text )
- * obs-text    = %x80-FF
- */
-const QESC_REGEXP = /\\([\u000b\u0020-\u00ff])/g; // eslint-disable-line no-control-regex
 
 /**
  * RegExp to match chars that must be quoted-pair in RFC 7230 sec 3.2.6
  */
-const QUOTE_REGEXP = /([\\"])/g;
+const QUOTE_REGEXP = /[\\"]/g;
 
 /**
  * RegExp to match type in RFC 7231 sec 3.1.1.1
@@ -67,8 +42,7 @@ export function format(obj: ContentTypeFormat): string {
     throw new TypeError("argument obj is required");
   }
 
-  const parameters = obj.parameters;
-  const type = obj.type;
+  const { type, parameters } = obj;
 
   if (!type || !TYPE_REGEXP.test(type)) {
     throw new TypeError("invalid type");
@@ -78,16 +52,12 @@ export function format(obj: ContentTypeFormat): string {
 
   // append parameters
   if (parameters && typeof parameters === "object") {
-    const params = Object.keys(parameters).sort();
-
-    for (let i = 0; i < params.length; i++) {
-      const param = params[i];
-
+    for (const param of Object.keys(parameters).sort()) {
       if (!TOKEN_REGEXP.test(param)) {
         throw new TypeError("invalid parameter name");
       }
 
-      string += "; " + param + "=" + qstring(parameters[param]);
+      string += `; ${param}=${qstring(parameters[param])}`;
     }
   }
 
@@ -99,67 +69,37 @@ export function parse(string: string | ContentTypeSource): ContentType {
     throw new TypeError("argument string is required");
   }
 
-  // support req/res-like objects as argument
   const header = typeof string === "object" ? getcontenttype(string) : string;
 
   if (typeof header !== "string") {
     throw new TypeError("argument string is required to be a string");
   }
 
-  let index = header.indexOf(";");
-  const type = index !== -1 ? header.slice(0, index).trim() : header.trim();
+  const len = header.length;
+  const semiIndex = header.indexOf(";");
+  const end = semiIndex !== -1 ? semiIndex : len;
+  const valueStart = skipOWS(header, 0, end);
+  const valueEnd = trailingOWS(header, valueStart, end);
+  const type =
+    valueStart === 0 && valueEnd === len
+      ? header.toLowerCase()
+      : header.slice(valueStart, valueEnd).toLowerCase();
 
   if (!TYPE_REGEXP.test(type)) {
     throw new TypeError("invalid media type");
   }
 
-  const obj = new ContentTypeImpl(type.toLowerCase());
+  const parameters = parseParameters(header, end, len);
 
-  // parse parameters
-  if (index !== -1) {
-    let match: RegExpExecArray | null;
-
-    PARAM_REGEXP.lastIndex = index;
-
-    while ((match = PARAM_REGEXP.exec(header))) {
-      if (match.index !== index) {
-        throw new TypeError("invalid parameter format");
-      }
-
-      index += match[0].length;
-
-      const key = match[1].toLowerCase();
-      let value = match[2];
-
-      if (value.charCodeAt(0) === 0x22 /* " */) {
-        // remove quotes
-        value = value.slice(1, -1);
-
-        // remove escapes
-        if (value.indexOf("\\") !== -1) {
-          value = value.replace(QESC_REGEXP, "$1");
-        }
-      }
-
-      obj.parameters[key] = value;
-    }
-
-    if (index !== header.length) {
-      throw new TypeError("invalid parameter format");
-    }
-  }
-
-  return obj;
+  return { type, parameters };
 }
 
 function getcontenttype(obj: ContentTypeSource): string {
   let header: unknown;
 
   if (typeof obj.getHeader === "function") {
-    // res-like
     header = obj.getHeader("content-type");
   } else if (typeof obj.headers === "object") {
-    // req-like
     header = obj.headers && obj.headers["content-type"];
   }
 
@@ -168,6 +108,95 @@ function getcontenttype(obj: ContentTypeSource): string {
   }
 
   return header;
+}
+
+function parseParameters(
+  header: string,
+  index: number,
+  len: number,
+): Record<string, string> {
+  const parameters = Object.create(null);
+
+  while (index < len) {
+    // Skip `;` and OWS before parameter key.
+    index = skipOWS(header, index + 1, len);
+
+    const keyStart = index;
+
+    while (index < len) {
+      const char = header[index];
+      if (char === ";") break; // End of parameter, no value found, skip.
+
+      if (char === "=") {
+        const keyEnd = trailingOWS(header, keyStart, index);
+        const key = header.slice(keyStart, keyEnd).toLowerCase();
+
+        index = skipOWS(header, index + 1, len);
+
+        if (header[index] === '"') {
+          index++;
+
+          let value = "";
+          while (index < len) {
+            const char = header[index++];
+            if (char === '"') {
+              let validTrailingOWS = true;
+
+              // Increment to next parameter.
+              while (index < len) {
+                const char = header[index];
+                if (char === ";") break;
+                validTrailingOWS &&= char === " " || char === "\t";
+                index++;
+              }
+
+              // Ignore parameters with non-OWS after closing quote as undefined behavior.
+              if (validTrailingOWS) parameters[key] = value;
+              break;
+            }
+
+            if (char === "\\") {
+              value += header[index++];
+              continue;
+            }
+
+            value += char;
+          }
+
+          break;
+        }
+
+        const valueStart = index;
+        while (index < len && header[index] !== ";") index++;
+
+        const valueEnd = trailingOWS(header, valueStart, index);
+        parameters[key] = header.slice(valueStart, valueEnd);
+        break;
+      }
+
+      index++;
+    }
+  }
+
+  return parameters;
+}
+
+function skipOWS(header: string, index: number, len: number): number {
+  while (index < len) {
+    const code = header[index];
+    if (code !== " " && code !== "\t") break;
+    index++;
+  }
+  return index;
+}
+
+function trailingOWS(header: string, start: number, end: number): number {
+  while (end > start) {
+    const code = header[end - 1];
+    if (code !== " " && code !== "\t") break;
+    end--;
+  }
+  return end;
 }
 
 function qstring(val: unknown): string {
@@ -182,15 +211,5 @@ function qstring(val: unknown): string {
     throw new TypeError("invalid parameter value");
   }
 
-  return '"' + str.replace(QUOTE_REGEXP, "\\$1") + '"';
-}
-
-class ContentTypeImpl implements ContentType {
-  parameters: Record<string, string>;
-  type: string;
-
-  constructor(type: string) {
-    this.parameters = Object.create(null);
-    this.type = type;
-  }
+  return '"' + str.replace(QUOTE_REGEXP, "\\$&") + '"';
 }

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, assert } from "vitest";
 import { parse } from "./index";
-import { a } from "vitest/dist/chunks/suite.d.FvehnV49.js";
 
 const invalidTypes = [
   " ",
@@ -131,12 +130,11 @@ describe("parse(string)", function () {
     });
   });
 
-  it("should omit unterminated quoted parameters", function () {
-    var type = parse('text/plain; foo="bar');
-    assert.deepEqual(type, {
-      type: "text/plain",
-      parameters: {},
-    });
+  it("should error on unterminated quoted parameter", function () {
+    assert.throws(
+      () => parse('text/plain; foo="bar'),
+      /unexpected end of input/,
+    );
   });
 
   it("should error on non-OWS after closing quote", function () {

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -113,25 +113,59 @@ describe("parse(string)", function () {
     });
   });
 
+  it("should ignore extra semicolons", function () {
+    var type = parse("text/html;;;; charset=utf-8;; foo=bar;");
+    assert.deepEqual(type, {
+      type: "text/html",
+      parameters: {
+        charset: "utf-8",
+        foo: "bar",
+      },
+    });
+  });
+
   invalidTypes.forEach(function (type) {
     it("should throw on invalid media type " + type, function () {
       assert.throws(parse.bind(null, type), /invalid media type/);
     });
   });
 
-  it("should throw on invalid parameter format", function () {
-    assert.throws(
-      parse.bind(null, 'text/plain; foo="bar'),
-      /invalid parameter format/,
-    );
-    assert.throws(
-      parse.bind(null, "text/plain; profile=http://localhost; foo=bar"),
-      /invalid parameter format/,
-    );
-    assert.throws(
-      parse.bind(null, "text/plain; profile=http://localhost"),
-      /invalid parameter format/,
-    );
+  it("should omit unterminated quoted parameters", function () {
+    var type = parse('text/plain; foo="bar');
+    assert.deepEqual(type, {
+      type: "text/plain",
+      parameters: {},
+    });
+  });
+
+  it("should skip quoted parameters with non-OWS after closing quote", function () {
+    var type = parse('text/plain; foo="bar"xyz; baz=qux');
+    assert.deepEqual(type, {
+      type: "text/plain",
+      parameters: {
+        baz: "qux",
+      },
+    });
+  });
+
+  it("should allow quotes in unquoted parameter values", function () {
+    var type = parse('text/plain; foo=bar"baz');
+    assert.deepEqual(type, {
+      type: "text/plain",
+      parameters: {
+        foo: 'bar"baz',
+      },
+    });
+  });
+
+  it("should allow equals in unquoted parameter values", function () {
+    var type = parse("text/plain; foo=bar=baz");
+    assert.deepEqual(type, {
+      type: "text/plain",
+      parameters: {
+        foo: "bar=baz",
+      },
+    });
   });
 
   it("should require argument", function () {

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, assert } from "vitest";
 import { parse } from "./index";
+import { a } from "vitest/dist/chunks/suite.d.FvehnV49.js";
 
 const invalidTypes = [
   " ",
@@ -138,14 +139,11 @@ describe("parse(string)", function () {
     });
   });
 
-  it("should skip quoted parameters with non-OWS after closing quote", function () {
-    var type = parse('text/plain; foo="bar"xyz; baz=qux');
-    assert.deepEqual(type, {
-      type: "text/plain",
-      parameters: {
-        baz: "qux",
-      },
-    });
+  it("should error on non-OWS after closing quote", function () {
+    assert.throws(
+      parse.bind(null, 'text/plain; foo="bar"baz'),
+      /unexpected non-separator character/,
+    );
   });
 
   it("should allow quotes in unquoted parameter values", function () {


### PR DESCRIPTION
Building on https://github.com/jshttp/content-type/pull/57 for benchmarking. Rewrites the parser to be incremental without regex validation, and more lenient for [upstream dependents](https://github.com/pillarjs/multiparty/blob/caf5aac216d4938e73f18e4d900b1dc6b3647c57/test/fixture/http/content-type/custom-equal-sign.http#L3) who need things like `foo=bar=baz` to be parsed correctly.