### PR TITLE
Remove API overhead and checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const str = contentType.format({
 Format an object into a `Content-Type` header. This will return a string of the content type for the given object with the following properties (examples are shown that produce the string `'image/svg+xml; charset=utf-8'`):
 
 - `type`: The media type (will be lower-cased). Example: `'image/svg+xml'`.
-- `parameters`: An object of the parameters in the media type (parameter name will be lower cased). Example: `{charset: 'utf-8'}`
+- `parameters`: An optional object of the parameters in the media type. Example: `{charset: 'utf-8'}`.
 
 Throws a `TypeError` if the object contains an invalid type or parameter names.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ const obj = contentType.parse("image/svg+xml; charset=utf-8");
 Parse a `Content-Type` header. This will return an object with the following properties (examples are shown for the string `'image/svg+xml; charset=utf-8'`):
 
 - `type`: The media type. Example: `'image/svg+xml'`.
-- `parameters`: An object of the parameters in the media type (parameter name is always lower case). Example: `{charset: 'utf-8'}`.
+- `parameters`: An optional object of the parameters in the media type (parameter name is always lower case). Example: `{charset: 'utf-8'}`.
+
+The parser is lenient, but will throw a `TypeError` when unable to parse a parameter due to ambiguity. E.g. `foo="` where the quote is unterminated.
 
 ### contentType.format(obj)
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 [![Build Status][ci-image]][ci-url]
 [![Coverage Status][coveralls-image]][coveralls-url]
 
-Create and parse HTTP Content-Type header according to RFC 7231
+Create and parse HTTP `Content-Type` header.
 
 ## Installation
 
 ```sh
-$ npm install content-type
+npm install content-type
 ```
 
 ## API
@@ -26,38 +26,10 @@ const contentType = require("content-type");
 const obj = contentType.parse("image/svg+xml; charset=utf-8");
 ```
 
-Parse a `Content-Type` header. This will return an object with the following
-properties (examples are shown for the string `'image/svg+xml; charset=utf-8'`):
+Parse a `Content-Type` header. This will return an object with the following properties (examples are shown for the string `'image/svg+xml; charset=utf-8'`):
 
-- `type`: The media type (the type and subtype, always lower case).
-  Example: `'image/svg+xml'`
-
-- `parameters`: An object of the parameters in the media type (name of parameter
-  always lower case). Example: `{charset: 'utf-8'}`
-
-Throws a `TypeError` if the string is missing or invalid.
-
-### contentType.parse(req)
-
-```js
-const obj = contentType.parse(req);
-```
-
-Parse the `Content-Type` header from the given `req`. Short-cut for
-`contentType.parse(req.headers['content-type'])`.
-
-Throws a `TypeError` if the `Content-Type` header is missing or invalid.
-
-### contentType.parse(res)
-
-```js
-const obj = contentType.parse(res);
-```
-
-Parse the `Content-Type` header set on the given `res`. Short-cut for
-`contentType.parse(res.getHeader('content-type'))`.
-
-Throws a `TypeError` if the `Content-Type` header is missing or invalid.
+- `type`: The media type. Example: `'image/svg+xml'`.
+- `parameters`: An object of the parameters in the media type (parameter name is always lower case). Example: `{charset: 'utf-8'}`.
 
 ### contentType.format(obj)
 
@@ -68,14 +40,10 @@ const str = contentType.format({
 });
 ```
 
-Format an object into a `Content-Type` header. This will return a string of the
-content type for the given object with the following properties (examples are
-shown that produce the string `'image/svg+xml; charset=utf-8'`):
+Format an object into a `Content-Type` header. This will return a string of the content type for the given object with the following properties (examples are shown that produce the string `'image/svg+xml; charset=utf-8'`):
 
-- `type`: The media type (will be lower-cased). Example: `'image/svg+xml'`
-
-- `parameters`: An object of the parameters in the media type (name of the
-  parameter will be lower-cased). Example: `{charset: 'utf-8'}`
+- `type`: The media type (will be lower-cased). Example: `'image/svg+xml'`.
+- `parameters`: An object of the parameters in the media type (parameter name will be lower cased). Example: `{charset: 'utf-8'}`
 
 Throws a `TypeError` if the object contains an invalid type or parameter names.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "http",
     "req",
     "res",
-    "rfc7231"
+    "rfc7231",
+    "rfc9110"
   ],
   "repository": "jshttp/content-type",
   "funding": {
@@ -24,6 +25,7 @@
     "dist/"
   ],
   "scripts": {
+    "bench": "vitest bench",
     "build": "ts-scripts build",
     "format": "ts-scripts format",
     "lint": "ts-scripts lint",

--- a/src/format.spec.ts
+++ b/src/format.spec.ts
@@ -41,42 +41,26 @@ describe("format(obj)", function () {
       type: "text/html",
       parameters: { charset: "utf-8", foo: "bar", bar: "baz" },
     });
-    assert.strictEqual(str, "text/html; bar=baz; charset=utf-8; foo=bar");
-  });
-
-  it("should require argument", function () {
-    assert.throws(
-      format.bind(null, undefined as any),
-      /argument obj is required/,
-    );
-  });
-
-  it("should reject non-objects", function () {
-    assert.throws(format.bind(null, 7 as any), /argument obj is required/);
-  });
-
-  it("should require type", function () {
-    const obj = {};
-    assert.throws(format.bind(null, obj as any), /invalid type/);
+    assert.strictEqual(str, "text/html; charset=utf-8; foo=bar; bar=baz");
   });
 
   it("should reject invalid type", function () {
     const obj = { type: "text/" };
-    assert.throws(format.bind(null, obj), /invalid type/);
+    assert.throws(format.bind(null, obj), /Invalid type: text\//);
   });
 
   it("should reject invalid type with LWS", function () {
     const obj = { type: " text/html" };
-    assert.throws(format.bind(null, obj), /invalid type/);
+    assert.throws(format.bind(null, obj), /Invalid type:  text\/html/);
   });
 
   it("should reject invalid parameter name", function () {
     const obj = { type: "image/svg", parameters: { "foo/": "bar" } };
-    assert.throws(format.bind(null, obj), /invalid parameter name/);
+    assert.throws(format.bind(null, obj), /Invalid parameter name: foo\//);
   });
 
   it("should reject invalid parameter value", function () {
     const obj = { type: "image/svg", parameters: { foo: "bar\u0000" } };
-    assert.throws(format.bind(null, obj), /invalid parameter value/);
+    assert.throws(format.bind(null, obj), /Invalid parameter value: bar\u0000/);
   });
 });

--- a/src/index.bench.ts
+++ b/src/index.bench.ts
@@ -1,0 +1,71 @@
+import { bench, describe } from "vitest";
+import { format, parse } from "./index";
+
+describe("parse", () => {
+  const BASIC_HEADER = "text/html";
+  const PARAMS_HEADER = "application/json; charset=utf-8; foo=bar; version=1";
+  const QUOTED_HEADER =
+    'text/plain; filename="report\\"-2026.csv"; foo=bar; version=1';
+  const OWS_HEADER =
+    "application/json; \t  charset = utf-8 ;\t foo = bar ; version = 1";
+  const MANY_PARAMS_HEADER =
+    "application/json; a=1; b=2; c=3; d=4; e=5; f=6; g=7; h=8; i=9; j=10";
+  const ESCAPED_HEAVY_HEADER =
+    'text/plain; filename="quarterly\\\\report\\"-2026.csv"; path="C:\\\\temp\\\\files"; note="a\\\\b\\\\c\\\\d"; version=1';
+
+  bench("basic", () => {
+    parse(BASIC_HEADER);
+  });
+
+  bench("simple parameters", () => {
+    parse(PARAMS_HEADER);
+  });
+
+  bench("quoted and escaped parameters", () => {
+    parse(QUOTED_HEADER);
+  });
+
+  bench("OWS-heavy parameters", () => {
+    parse(OWS_HEADER);
+  });
+
+  bench("many parameters", () => {
+    parse(MANY_PARAMS_HEADER);
+  });
+
+  bench("escape-heavy quoted parameters", () => {
+    parse(ESCAPED_HEAVY_HEADER);
+  });
+});
+
+describe("format", () => {
+  const BASIC_OBJECT = { type: "text/html" };
+  const PARAMS_OBJECT = {
+    type: "application/json",
+    parameters: {
+      charset: "utf-8",
+      profile: "urn:example:v1",
+      version: "1",
+    },
+  };
+  const QUOTED_OBJECT = {
+    type: "text/plain",
+    parameters: {
+      filename: 'report"-2026.csv',
+      foo: "test=bar",
+      q: "0.9",
+    },
+  };
+
+  bench("basic", () => {
+    format(BASIC_OBJECT);
+  });
+
+  bench("simple parameters", () => {
+    format(PARAMS_OBJECT);
+  });
+
+  bench("quoted and escaped parameters", () => {
+    format(QUOTED_OBJECT);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,11 +22,17 @@ const QUOTE_REGEXP = /[\\"]/g;
 const TYPE_REGEXP =
   /^[!#$%&'*+.^_`|~0-9A-Za-z-]+\/[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 
+/**
+ * The content type object contains a type string and optional parameters.
+ */
 export interface ContentType {
-  parameters?: Record<string, string>;
   type: string;
+  parameters?: Record<string, string>;
 }
 
+/**
+ * Format an object into a `Content-Type` header.
+ */
 export function format(obj: ContentType): string {
   const { type, parameters } = obj;
 
@@ -49,6 +55,9 @@ export function format(obj: ContentType): string {
   return result;
 }
 
+/**
+ * Parse a `Content-Type` header.
+ */
 export function parse(header: string): ContentType {
   const len = header.length;
   const semiIndex = header.indexOf(";");

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,41 +4,16 @@
  * MIT Licensed
  */
 
-/**
- * RegExp to match *( ";" parameter ) in RFC 7231 sec 3.1.1.1
- *
- * parameter     = token "=" ( token / quoted-string )
- * token         = 1*tchar
- * tchar         = "!" / "#" / "$" / "%" / "&" / "'" / "*"
- *               / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
- *               / DIGIT / ALPHA
- *               ; any VCHAR, except delimiters
- * quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE
- * qdtext        = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
- * obs-text      = %x80-FF
- * quoted-pair   = "\\" ( HTAB / SP / VCHAR / obs-text )
- */
-const PARAM_REGEXP =
-  /;[\t ]*([!#$%&'*+.^_`|~0-9A-Za-z-]+)[\t ]*=[\t ]*("(?:[\u000b\u0020\u0021\u0023-\u005b\u005d-\u007e\u0080-\u00ff]|\\[\u000b\u0020-\u00ff])*"|[!#$%&'*+.^_`|~0-9A-Za-z-]+)[\t ]*/g;
-
-const TEXT_REGEXP = /^[\u000b\u0020-\u007e\u0080-\u00ff]+$/; // eslint-disable-line no-control-regex
+const TEXT_REGEXP = /^[\u000b\u0020-\u007e\u0080-\u00ff]*$/;
 const TOKEN_REGEXP = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 
 /**
- * RegExp to match quoted-pair in RFC 7230 sec 3.2.6
- *
- * quoted-pair = "\\" ( HTAB / SP / VCHAR / obs-text )
- * obs-text    = %x80-FF
+ * RegExp to match chars that must be quoted-pair in RFC 9110 sec 5.6.4
  */
-const QESC_REGEXP = /\\([\u000b\u0020-\u00ff])/g; // eslint-disable-line no-control-regex
+const QUOTE_REGEXP = /[\\"]/g;
 
 /**
- * RegExp to match chars that must be quoted-pair in RFC 7230 sec 3.2.6
- */
-const QUOTE_REGEXP = /([\\"])/g;
-
-/**
- * RegExp to match type in RFC 7231 sec 3.1.1.1
+ * RegExp to match type in RFC 9110 sec 8.3.1
  *
  * media-type = type "/" subtype
  * type       = token
@@ -48,149 +23,145 @@ const TYPE_REGEXP =
   /^[!#$%&'*+.^_`|~0-9A-Za-z-]+\/[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 
 export interface ContentType {
-  parameters: Record<string, string>;
+  parameters?: Record<string, string>;
   type: string;
 }
 
-export interface ContentTypeFormat {
-  parameters?: Record<string, unknown>;
-  type: string;
-}
-
-export type ContentTypeSource = {
-  getHeader?: (name: string) => unknown;
-  headers?: Record<string, unknown>;
-};
-
-export function format(obj: ContentTypeFormat): string {
-  if (!obj || typeof obj !== "object") {
-    throw new TypeError("argument obj is required");
-  }
-
-  const parameters = obj.parameters;
-  const type = obj.type;
+export function format(obj: ContentType): string {
+  const { type, parameters } = obj;
 
   if (!type || !TYPE_REGEXP.test(type)) {
-    throw new TypeError("invalid type");
+    throw new TypeError(`Invalid type: ${type}`);
   }
 
-  let string = type;
+  let result = type;
 
-  // append parameters
-  if (parameters && typeof parameters === "object") {
-    const params = Object.keys(parameters).sort();
-
-    for (let i = 0; i < params.length; i++) {
-      const param = params[i];
-
+  if (parameters) {
+    for (const param of Object.keys(parameters)) {
       if (!TOKEN_REGEXP.test(param)) {
-        throw new TypeError("invalid parameter name");
+        throw new TypeError(`Invalid parameter name: ${param}`);
       }
 
-      string += "; " + param + "=" + qstring(parameters[param]);
+      result += `; ${param}=${qstring(parameters[param])}`;
     }
   }
 
-  return string;
+  return result;
 }
 
-export function parse(string: string | ContentTypeSource): ContentType {
-  if (!string) {
-    throw new TypeError("argument string is required");
-  }
+export function parse(header: string): ContentType {
+  const len = header.length;
+  const semiIndex = header.indexOf(";");
+  const end = semiIndex !== -1 ? semiIndex : len;
+  const valueStart = skipOWS(header, 0, end);
+  const valueEnd = trailingOWS(header, valueStart, end);
+  const type = header.slice(valueStart, valueEnd).toLowerCase();
 
-  // support req/res-like objects as argument
-  const header = typeof string === "object" ? getcontenttype(string) : string;
+  if (semiIndex === -1) return { type };
 
-  if (typeof header !== "string") {
-    throw new TypeError("argument string is required to be a string");
-  }
+  const parameters = parseParameters(header, end, len);
+  return { type, parameters };
+}
 
-  let index = header.indexOf(";");
-  const type = index !== -1 ? header.slice(0, index).trim() : header.trim();
+function parseParameters(
+  header: string,
+  index: number,
+  len: number,
+): Record<string, string> {
+  const parameters: Record<string, string> = Object.create(null);
 
-  if (!TYPE_REGEXP.test(type)) {
-    throw new TypeError("invalid media type");
-  }
+  parameter: while (index < len) {
+    index = skipOWS(header, index + 1, len);
 
-  const obj = new ContentTypeImpl(type.toLowerCase());
+    const keyStart = index;
 
-  // parse parameters
-  if (index !== -1) {
-    let match: RegExpExecArray | null;
+    while (index < len) {
+      const char = header[index];
+      if (char === ";") continue parameter;
 
-    PARAM_REGEXP.lastIndex = index;
+      if (char === "=") {
+        const keyEnd = trailingOWS(header, keyStart, index);
+        const key = header.slice(keyStart, keyEnd).toLowerCase();
 
-    while ((match = PARAM_REGEXP.exec(header))) {
-      if (match.index !== index) {
-        throw new TypeError("invalid parameter format");
-      }
+        index = skipOWS(header, index + 1, len);
 
-      index += match[0].length;
+        if (header[index] === '"') {
+          index++;
 
-      const key = match[1].toLowerCase();
-      let value = match[2];
+          let value = "";
+          while (index < len) {
+            const char = header[index++];
+            if (char === '"') {
+              index = skipOWS(header, index, len);
+              if (index < len && header[index] !== ";") {
+                throw new TypeError(
+                  `Unexpected characters after parameter at index ${index}`,
+                );
+              }
 
-      if (value.charCodeAt(0) === 0x22 /* " */) {
-        // remove quotes
-        value = value.slice(1, -1);
+              parameters[key] = value;
+              continue parameter;
+            }
 
-        // remove escapes
-        if (value.indexOf("\\") !== -1) {
-          value = value.replace(QESC_REGEXP, "$1");
+            if (char === "\\") {
+              value += header[index++];
+              continue;
+            }
+
+            value += char;
+          }
+
+          throw new TypeError(`Unexpected end of input at index ${index}`);
         }
+
+        const valueStart = index;
+        while (index < len && header[index] !== ";") {
+          index++;
+        }
+
+        const valueEnd = trailingOWS(header, valueStart, index);
+        parameters[key] = header.slice(valueStart, valueEnd);
+        continue parameter;
       }
 
-      obj.parameters[key] = value;
-    }
-
-    if (index !== header.length) {
-      throw new TypeError("invalid parameter format");
+      index++;
     }
   }
 
-  return obj;
+  return parameters;
 }
 
-function getcontenttype(obj: ContentTypeSource): string {
-  let header: unknown;
-
-  if (typeof obj.getHeader === "function") {
-    // res-like
-    header = obj.getHeader("content-type");
-  } else if (typeof obj.headers === "object") {
-    // req-like
-    header = obj.headers && obj.headers["content-type"];
+/**
+ * Skip optional whitespace (OWS) in an HTTP header value.
+ *
+ * OWS is defined in RFC 9110 sec 5.6.3 as SP (" ") or HTAB ("\t").
+ */
+function skipOWS(header: string, index: number, len: number): number {
+  while (index < len) {
+    const char = header[index];
+    if (char !== " " && char !== "\t") break;
+    index++;
   }
-
-  if (typeof header !== "string") {
-    throw new TypeError("content-type header is missing from object");
-  }
-
-  return header;
+  return index;
 }
 
-function qstring(val: unknown): string {
-  const str = String(val);
-
-  // no need to quote tokens
-  if (TOKEN_REGEXP.test(str)) {
-    return str;
+/**
+ * Trim optional whitespace (OWS) from the end of a substring.
+ *
+ * OWS is defined in RFC 9110 sec 5.6.3 as SP (" ") or HTAB ("\t").
+ */
+function trailingOWS(header: string, start: number, end: number): number {
+  while (end > start) {
+    const char = header[end - 1];
+    if (char !== " " && char !== "\t") break;
+    end--;
   }
-
-  if (str.length > 0 && !TEXT_REGEXP.test(str)) {
-    throw new TypeError("invalid parameter value");
-  }
-
-  return '"' + str.replace(QUOTE_REGEXP, "\\$1") + '"';
+  return end;
 }
 
-class ContentTypeImpl implements ContentType {
-  parameters: Record<string, string>;
-  type: string;
+function qstring(str: string): string {
+  if (TOKEN_REGEXP.test(str)) return str;
+  if (TEXT_REGEXP.test(str)) return `"${str.replace(QUOTE_REGEXP, "\\$&")}"`;
 
-  constructor(type: string) {
-    this.parameters = Object.create(null);
-    this.type = type;
-  }
+  throw new TypeError(`Invalid parameter value: ${str}`);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,7 @@ function parseParameters(
             }
 
             if (char === "\\") {
+              if (index === len) break;
               value += header[index++];
               continue;
             }

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -7,7 +7,7 @@ const invalidTypes = [
   "undefined",
   "/",
   "text / plain",
-  "text/;plain",
+  "text/$plain",
   'text/"plain"',
   "text/p£ain",
   "text/(plain)",
@@ -20,7 +20,12 @@ describe("parse(string)", function () {
     const type = parse("text/html");
     assert.deepEqual(type, {
       type: "text/html",
-      parameters: {},
+    });
+  });
+
+  it.each(invalidTypes)("should accept invalid types: %s", function (str) {
+    assert.deepEqual(parse(str), {
+      type: str.trim().toLowerCase(),
     });
   });
 
@@ -28,7 +33,6 @@ describe("parse(string)", function () {
     const type = parse("image/svg+xml");
     assert.deepEqual(type, {
       type: "image/svg+xml",
-      parameters: {},
     });
   });
 
@@ -36,7 +40,6 @@ describe("parse(string)", function () {
     const type = parse(" text/html ");
     assert.deepEqual(type, {
       type: "text/html",
-      parameters: {},
     });
   });
 
@@ -62,11 +65,50 @@ describe("parse(string)", function () {
     });
   });
 
+  it("should parse empty parameter value", function () {
+    const type = parse("text/html; charset=");
+    assert.deepEqual(type, {
+      type: "text/html",
+      parameters: {
+        charset: "",
+      },
+    });
+  });
+
+  it("should parse empty parameter value with quotes", function () {
+    const type = parse('text/html; charset=""');
+    assert.deepEqual(type, {
+      type: "text/html",
+      parameters: {
+        charset: "",
+      },
+    });
+  });
+
+  it("should parse empty parameter value with OWS", function () {
+    const type = parse("text/html; charset= ");
+    assert.deepEqual(type, {
+      type: "text/html",
+      parameters: {
+        charset: "",
+      },
+    });
+  });
+
+  it("should parse parameters with OWS around equals", function () {
+    const type = parse("text/html; charset = utf-8");
+    assert.deepEqual(type, {
+      type: "text/html",
+      parameters: {
+        charset: "utf-8",
+      },
+    });
+  });
+
   it("should lower-case type", function () {
     const type = parse("IMAGE/SVG+XML");
     assert.deepEqual(type, {
       type: "image/svg+xml",
-      parameters: {},
     });
   });
 
@@ -113,70 +155,48 @@ describe("parse(string)", function () {
     });
   });
 
-  invalidTypes.forEach(function (type) {
-    it("should throw on invalid media type " + type, function () {
-      assert.throws(parse.bind(null, type), /invalid media type/);
+  it("should ignore extra semicolons", function () {
+    var type = parse("text/html;;;; charset=utf-8;; foo=bar;");
+    assert.deepEqual(type, {
+      type: "text/html",
+      parameters: {
+        charset: "utf-8",
+        foo: "bar",
+      },
     });
   });
 
-  it("should throw on invalid parameter format", function () {
+  it("should error on unterminated quoted parameter", function () {
     assert.throws(
-      parse.bind(null, 'text/plain; foo="bar'),
-      /invalid parameter format/,
-    );
-    assert.throws(
-      parse.bind(null, "text/plain; profile=http://localhost; foo=bar"),
-      /invalid parameter format/,
-    );
-    assert.throws(
-      parse.bind(null, "text/plain; profile=http://localhost"),
-      /invalid parameter format/,
+      () => parse('text/plain; foo="bar'),
+      /Unexpected end of input at index 20/,
     );
   });
 
-  it("should require argument", function () {
-    assert.throws(parse.bind(null, undefined as any), /string.*required/);
+  it("should error on non-OWS after closing quote", function () {
+    assert.throws(
+      parse.bind(null, 'text/plain; foo="bar"baz'),
+      /Unexpected characters after parameter at index 21/,
+    );
   });
 
-  it("should reject non-strings", function () {
-    assert.throws(parse.bind(null, 7 as any), /string.*required/);
-  });
-});
-
-describe("parse(req)", function () {
-  it("should parse content-type header", function () {
-    const req = { headers: { "content-type": "text/html" } };
-    const type = parse(req);
-    assert.strictEqual(type.type, "text/html");
-  });
-
-  it("should reject objects without headers property", function () {
-    assert.throws(parse.bind(null, {}), /content-type header is missing/);
-  });
-
-  it("should reject missing content-type", function () {
-    const req = { headers: {} };
-    assert.throws(parse.bind(null, req), /content-type header is missing/);
-  });
-});
-
-describe("parse(res)", function () {
-  it("should parse content-type header", function () {
-    const res = {
-      getHeader: function () {
-        return "text/html";
+  it("should allow quotes in unquoted parameter values", function () {
+    var type = parse('text/plain; foo=bar"baz');
+    assert.deepEqual(type, {
+      type: "text/plain",
+      parameters: {
+        foo: 'bar"baz',
       },
-    };
-    const type = parse(res);
-    assert.strictEqual(type.type, "text/html");
+    });
   });
 
-  it("should reject objects without getHeader method", function () {
-    assert.throws(parse.bind(null, {}), /content-type header is missing/);
-  });
-
-  it("should reject missing content-type", function () {
-    const res = { getHeader: function () {} };
-    assert.throws(parse.bind(null, res), /content-type header is missing/);
+  it("should allow equals in unquoted parameter values", function () {
+    var type = parse("text/plain; foo=bar=baz");
+    assert.deepEqual(type, {
+      type: "text/plain",
+      parameters: {
+        foo: "bar=baz",
+      },
+    });
   });
 });

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -16,6 +16,13 @@ const invalidTypes = [
 ];
 
 describe("parse(string)", function () {
+  it("should parse empty string", function () {
+    const type = parse("");
+    assert.deepEqual(type, {
+      type: "",
+    });
+  });
+
   it("should parse basic type", function () {
     const type = parse("text/html");
     assert.deepEqual(type, {

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -173,6 +173,13 @@ describe("parse(string)", function () {
     );
   });
 
+  it("should error on backslash at end of input in quoted parameter", function () {
+    assert.throws(
+      () => parse('text/plain; foo="bar\\'),
+      /Unexpected end of input at index 21/,
+    );
+  });
+
   it("should error on non-OWS after closing quote", function () {
     assert.throws(
       parse.bind(null, 'text/plain; foo="bar"baz'),


### PR DESCRIPTION
Based on the improved parser PR, this one takes things further with major breaking changes to the API. It's intended to provide basic performance boosts and ignore things that are likely already occurring upstream or downstream of the package.

Example:

- Accept string input only. Currently it accepts `req`/`res` objects but throws when the header field is missing. This would require upstream to grab it and validate behavior already, negating the need for these shortcuts.
- Made `parameters` optional for a ~10% perf boost when no parameters present.
- Stopped validating type on the parser (should done downstream anyway, no need to check the format is ideal here) for ~10% improvement across all benchmarks.
- Stopped sorting parameter names, use object ordering provided in `format` (>10% boost when parameters are present)