### PR TITLE
Null object perf optimization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,15 @@ const TYPE_REGEXP =
   /^[!#$%&'*+.^_`|~0-9A-Za-z-]+\/[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 
 /**
+ * Null object perf optimization. Faster than `Object.create(null)` and `{ __proto__: null }`.
+ */
+const NullObject = /* @__PURE__ */ (() => {
+  const C = function () {};
+  C.prototype = Object.create(null);
+  return C;
+})() as unknown as { new (): any };
+
+/**
  * The content type object contains a type string and optional parameters.
  */
 export interface ContentType {
@@ -77,7 +86,7 @@ function parseParameters(
   index: number,
   len: number,
 ): Record<string, string> {
-  const parameters: Record<string, string> = Object.create(null);
+  const parameters: Record<string, string> = new NullObject();
 
   parameter: while (index < len) {
     index = skipOWS(header, index + 1, len);


### PR DESCRIPTION
Re-use the same object performance optimization from `cookie`.

Before:

```
 ✓ src/index.bench.ts > parse 8865ms
     name                                       hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · basic                           18,919,243.24  0.0000  0.0732  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.12%  9459622
   · simple parameters                2,872,463.60  0.0002  2.4601  0.0003  0.0003  0.0005  0.0009  0.0013  ±1.38%  1436232
   · quoted and escaped parameters    1,812,367.75  0.0004  1.0856  0.0006  0.0005  0.0007  0.0011  0.0032  ±0.85%   906184
   · OWS-heavy parameters             2,618,004.77  0.0003  3.6811  0.0004  0.0004  0.0005  0.0005  0.0015  ±1.68%  1309003
   · many parameters                  1,771,852.21  0.0004  0.5726  0.0006  0.0005  0.0007  0.0008  0.0014  ±0.63%   885927
   · escape-heavy quoted parameters   1,376,101.43  0.0006  0.7763  0.0007  0.0007  0.0011  0.0015  0.0040  ±0.69%   688051

 ✓ src/index.bench.ts > format 5323ms
     name                                      hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · basic                          15,995,839.71  0.0000  0.0662  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.15%  7997920
   · simple parameters               2,524,354.94  0.0003  0.2592  0.0004  0.0004  0.0005  0.0005  0.0011  ±0.34%  1262178
   · quoted and escaped parameters   1,737,386.42  0.0005  0.3717  0.0006  0.0006  0.0007  0.0007  0.0014  ±0.32%   868694
```

After:

```
 ✓ src/index.bench.ts > parse 9410ms
     name                                       hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · basic                           18,893,702.87  0.0000  0.2217  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.14%  9446852
   · simple parameters                3,121,528.69  0.0002  0.5578  0.0003  0.0003  0.0004  0.0004  0.0013  ±0.42%  1560765
   · quoted and escaped parameters    2,478,890.18  0.0003  0.6221  0.0004  0.0004  0.0005  0.0005  0.0013  ±0.55%  1239446
   · OWS-heavy parameters             2,844,042.67  0.0002  0.3197  0.0004  0.0004  0.0004  0.0005  0.0010  ±0.26%  1422022
   · many parameters                  2,327,318.55  0.0003  0.3799  0.0004  0.0004  0.0005  0.0005  0.0011  ±0.46%  1163660
   · escape-heavy quoted parameters   1,566,091.89  0.0005  0.4389  0.0006  0.0006  0.0007  0.0012  0.0029  ±0.53%   783046

 ✓ src/index.bench.ts > format 5002ms
     name                                      hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · basic                          16,388,277.05  0.0000  0.0603  0.0001  0.0001  0.0001  0.0001  0.0001  ±0.08%  8194139
   · simple parameters               2,537,007.83  0.0003  0.5182  0.0004  0.0004  0.0004  0.0005  0.0011  ±0.41%  1268504
   · quoted and escaped parameters   1,741,117.73  0.0005  0.4088  0.0006  0.0006  0.0006  0.0007  0.0013  ±0.32%   870560
```

All parameter parsing benchmarks are >= 5% faster.