### PR TITLE
Use char codes, common semicolon logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ const obj = contentType.parse("image/svg+xml; charset=utf-8");
 Parse a `Content-Type` header. This will return an object with the following properties (examples are shown for the string `'image/svg+xml; charset=utf-8'`):
 
 - `type`: The media type. Example: `'image/svg+xml'`.
-- `parameters`: An optional object of the parameters in the media type (parameter name is always lower case). Example: `{charset: 'utf-8'}`.
+- `parameters`: An object of the parameters in the media type (parameter name is always lower case). Example: `{charset: 'utf-8'}`.
 
-The parser is lenient, but will throw a `TypeError` when unable to parse a parameter due to ambiguity. E.g. `foo="` where the quote is unterminated.
+The parser is lenient and does not error. You should validate `type` and `parameters` before trusting them.
 
 #### Options
 
-- `parameters` (default: `true`): Set to `false` to skip parsing parameters, only returns `type`.
+- `parameters` (default: `true`): Set to `false` to skip parameters.
 
 ### contentType.format(obj)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ export function parse(header: string, options?: ParseOptions): ContentType {
   const valueEnd = trailingOWS(header, valueStart, index);
   const type = header.slice(valueStart, valueEnd).toLowerCase();
   const parameters =
-    options && options.parameters === false
+    options?.parameters === false
       ? new NullObject()
       : parseParameters(header, index, len);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,13 +36,13 @@ const NullObject = /* @__PURE__ */ (() => {
  */
 export interface ContentType {
   type: string;
-  parameters?: Record<string, string>;
+  parameters: Record<string, string>;
 }
 
 /**
  * Format an object into a `Content-Type` header.
  */
-export function format(obj: ContentType): string {
+export function format(obj: Partial<ContentType>): string {
   const { type, parameters } = obj;
 
   if (!type || !TYPE_REGEXP.test(type)) {
@@ -76,18 +76,30 @@ export interface ParseOptions {
  */
 export function parse(header: string, options?: ParseOptions): ContentType {
   const len = header.length;
-  const semiIndex = header.indexOf(";");
-  const end = semiIndex !== -1 ? semiIndex : len;
-  const valueStart = skipOWS(header, 0, end);
-  const valueEnd = trailingOWS(header, valueStart, end);
+  let index = skipOWS(header, 0, len);
+
+  const valueStart = index;
+  index = skipValue(header, index, len);
+  const valueEnd = trailingOWS(header, valueStart, index);
   const type = header.slice(valueStart, valueEnd).toLowerCase();
+  const parameters =
+    options && options.parameters === false
+      ? new NullObject()
+      : parseParameters(header, index, len);
 
-  if (semiIndex === -1 || options?.parameters === false) return { type };
-
-  const parameters = parseParameters(header, end + 1, len);
   return { type, parameters };
 }
 
+const SP = 32; // " "
+const HTAB = 9; // "\t"
+const SEMI = 59; // ";"
+const EQ = 61; // "="
+const DQUOTE = 34; // '"'
+const BSLASH = 92; // "\\"
+
+/**
+ * Parses the parameters of a `Content-Type` header starting at the given index.
+ */
 function parseParameters(
   header: string,
   index: number,
@@ -96,60 +108,47 @@ function parseParameters(
   const parameters: Record<string, string> = new NullObject();
 
   parameter: while (index < len) {
-    index = skipOWS(header, index, len);
+    index = skipOWS(header, index + 1 /* Skip over ; */, len);
 
     const keyStart = index;
 
     while (index < len) {
-      const char = header[index];
-      if (char === ";") {
-        index++;
-        continue parameter;
-      }
+      const code = header.charCodeAt(index);
+      if (code === SEMI) continue parameter;
 
-      if (char === "=") {
+      if (code === EQ) {
         const keyEnd = trailingOWS(header, keyStart, index);
         const key = header.slice(keyStart, keyEnd).toLowerCase();
 
         index = skipOWS(header, index + 1, len);
 
-        if (index < len && header[index] === '"') {
+        if (index < len && header.charCodeAt(index) === DQUOTE) {
           index++;
 
           let value = "";
           while (index < len) {
-            const char = header[index++];
-            if (char === '"') {
-              index = skipOWS(header, index, len);
-              if (index < len && header[index] !== ";") {
-                throw new TypeError(`Unexpected character at index ${index}`);
-              }
-
+            const code = header.charCodeAt(index++);
+            if (code === DQUOTE) {
+              index = skipValue(header, index, len);
               parameters[key] = value;
-              index++;
-              continue parameter;
+              break;
             }
 
-            if (char === "\\") {
-              if (index === len) break;
+            if (code === BSLASH && index < len) {
               value += header[index++];
               continue;
             }
 
-            value += char;
+            value += String.fromCharCode(code);
           }
 
-          throw new TypeError(`Unexpected end of input at index ${index}`);
+          continue parameter;
         }
 
         const valueStart = index;
-        while (index < len && header[index] !== ";") {
-          index++;
-        }
-
+        index = skipValue(header, index, len);
         const valueEnd = trailingOWS(header, valueStart, index);
         parameters[key] = header.slice(valueStart, valueEnd);
-        index++;
         continue parameter;
       }
 
@@ -161,14 +160,26 @@ function parseParameters(
 }
 
 /**
+ * Skip over characters until a semicolon.
+ */
+function skipValue(str: string, index: number, len: number): number {
+  while (index < len) {
+    const char = str.charCodeAt(index);
+    if (char === SEMI) break;
+    index++;
+  }
+  return index;
+}
+
+/**
  * Skip optional whitespace (OWS) in an HTTP header value.
  *
  * OWS is defined in RFC 9110 sec 5.6.3 as SP (" ") or HTAB ("\t").
  */
 function skipOWS(header: string, index: number, len: number): number {
   while (index < len) {
-    const char = header[index];
-    if (char !== " " && char !== "\t") break;
+    const char = header.charCodeAt(index);
+    if (char !== SP && char !== HTAB) break;
     index++;
   }
   return index;
@@ -181,13 +192,16 @@ function skipOWS(header: string, index: number, len: number): number {
  */
 function trailingOWS(header: string, start: number, end: number): number {
   while (end > start) {
-    const char = header[end - 1];
-    if (char !== " " && char !== "\t") break;
+    const char = header.charCodeAt(end - 1);
+    if (char !== SP && char !== HTAB) break;
     end--;
   }
   return end;
 }
 
+/**
+ * Serialize a parameter value.
+ */
 function qstring(str: string): string {
   if (TOKEN_REGEXP.test(str)) return str;
   if (TEXT_REGEXP.test(str)) return `"${str.replace(QUOTE_REGEXP, "\\$&")}"`;

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -20,6 +20,7 @@ describe("parse(string)", function () {
     const type = parse("");
     assert.deepEqual(type, {
       type: "",
+      parameters: {},
     });
   });
 
@@ -27,12 +28,14 @@ describe("parse(string)", function () {
     const type = parse("text/html");
     assert.deepEqual(type, {
       type: "text/html",
+      parameters: {},
     });
   });
 
   it.each(invalidTypes)("should accept invalid types: %s", function (str) {
     assert.deepEqual(parse(str), {
       type: str.trim().toLowerCase(),
+      parameters: {},
     });
   });
 
@@ -40,6 +43,7 @@ describe("parse(string)", function () {
     const type = parse("image/svg+xml");
     assert.deepEqual(type, {
       type: "image/svg+xml",
+      parameters: {},
     });
   });
 
@@ -47,6 +51,7 @@ describe("parse(string)", function () {
     const type = parse(" text/html ");
     assert.deepEqual(type, {
       type: "text/html",
+      parameters: {},
     });
   });
 
@@ -116,6 +121,7 @@ describe("parse(string)", function () {
     const type = parse("IMAGE/SVG+XML");
     assert.deepEqual(type, {
       type: "image/svg+xml",
+      parameters: {},
     });
   });
 
@@ -163,7 +169,7 @@ describe("parse(string)", function () {
   });
 
   it("should ignore extra semicolons", function () {
-    var type = parse("text/html;;;; charset=utf-8;; foo=bar;");
+    const type = parse("text/html;;;; charset=utf-8;; foo=bar;");
     assert.deepEqual(type, {
       type: "text/html",
       parameters: {
@@ -173,29 +179,42 @@ describe("parse(string)", function () {
     });
   });
 
-  it("should error on unterminated quoted parameter", function () {
-    assert.throws(
-      () => parse('text/plain; foo="bar'),
-      /Unexpected end of input at index 20/,
-    );
+  it("should ignore unterminated quoted parameter", function () {
+    assert.deepEqual(parse('text/plain; foo="bar'), {
+      type: "text/plain",
+      parameters: {},
+    });
   });
 
-  it("should error on backslash at end of input in quoted parameter", function () {
-    assert.throws(
-      () => parse('text/plain; foo="bar\\'),
-      /Unexpected end of input at index 21/,
-    );
+  it("should ignore unterminated quoted parameter with backslash", function () {
+    assert.deepEqual(parse('text/plain; foo="bar\\'), {
+      type: "text/plain",
+      parameters: {},
+    });
   });
 
-  it("should error on non-OWS after closing quote", function () {
-    assert.throws(
-      parse.bind(null, 'text/plain; foo="bar"baz'),
-      /Unexpected character at index 21/,
-    );
+  it("should parse and ignore non-OWS after closing quote", function () {
+    assert.deepEqual(parse('text/plain; foo="bar"baz'), {
+      type: "text/plain",
+      parameters: {
+        foo: "bar",
+      },
+    });
+  });
+
+  it("should continue parsing after non-OWS", function () {
+    const type = parse('text/plain; foo="bar"baz; charset=utf-8');
+    assert.deepEqual(type, {
+      type: "text/plain",
+      parameters: {
+        foo: "bar",
+        charset: "utf-8",
+      },
+    });
   });
 
   it("should allow quotes in unquoted parameter values", function () {
-    var type = parse('text/plain; foo=bar"baz');
+    const type = parse('text/plain; foo=bar"baz');
     assert.deepEqual(type, {
       type: "text/plain",
       parameters: {
@@ -205,7 +224,7 @@ describe("parse(string)", function () {
   });
 
   it("should allow equals in unquoted parameter values", function () {
-    var type = parse("text/plain; foo=bar=baz");
+    const type = parse("text/plain; foo=bar=baz");
     assert.deepEqual(type, {
       type: "text/plain",
       parameters: {
@@ -220,6 +239,7 @@ describe("parse(string)", function () {
     });
     assert.deepEqual(type, {
       type: "text/html",
+      parameters: {},
     });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "@borderless/ts-scripts/configs/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2019",
-    "lib": ["ES2019"],
+    "target": "es2020",
+    "lib": ["es2020"],
     "rootDir": "src",
     "outDir": "dist",
     "module": "nodenext",


### PR DESCRIPTION
Difficult to get a consistent benchmark but I believe this is faster after running it a few times.

- Adds back `parameters` as a required return (`NullObject` performance is negligible so it no longer makes sense to omit)
- Uses `charCodeAt` almost everywhere as it seems to benchmarks marginally faster
- Refactored the semicolon handling to a common function (re-used by type parsing and the lenient double quote logic)
- Makes malformed double quote get ignored

This makes `parse` completely error free, and aligns it more closely with `utils.MIMEType`. A main difference is the native node.js utility does include the malformed parameters instead of ignoring them. We can easily align behavior here if that makes sense.