### PR TITLE
Only accept first parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ function parseParameters(
             const code = header.charCodeAt(index++);
             if (code === DQUOTE) {
               index = skipValue(header, index, len);
-              parameters[key] = value;
+              if (parameters[key] === undefined) parameters[key] = value;
               break;
             }
 
@@ -147,8 +147,12 @@ function parseParameters(
 
         const valueStart = index;
         index = skipValue(header, index, len);
-        const valueEnd = trailingOWS(header, valueStart, index);
-        parameters[key] = header.slice(valueStart, valueEnd);
+
+        if (parameters[key] === undefined) {
+          const valueEnd = trailingOWS(header, valueStart, index);
+          parameters[key] = header.slice(valueStart, valueEnd);
+        }
+
         continue parameter;
       }
 

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -233,6 +233,36 @@ describe("parse(string)", function () {
     });
   });
 
+  it("should ignore duplicate parameters", function () {
+    const type = parse("text/html; charset=utf-8; charset=iso-8859-1");
+    assert.deepEqual(type, {
+      type: "text/html",
+      parameters: {
+        charset: "utf-8",
+      },
+    });
+  });
+
+  it("should ignore duplicate parameters with different case", function () {
+    const type = parse("text/html; Charset=utf-8; charset=iso-8859-1");
+    assert.deepEqual(type, {
+      type: "text/html",
+      parameters: {
+        charset: "utf-8",
+      },
+    });
+  });
+
+  it("should ignore duplicate parameters with quotes", function () {
+    const type = parse('text/html; Charset="utf-8"; charset="iso-8859-1"');
+    assert.deepEqual(type, {
+      type: "text/html",
+      parameters: {
+        charset: "utf-8",
+      },
+    });
+  });
+
   it("should skip parsing parameters when options.parameters is false", function () {
     const type = parse("text/html; charset=utf-8; foo=bar", {
       parameters: false,


### PR DESCRIPTION
Matches `util.MimeType` behavior.