### PR TITLE
Add an explicit default export to the module

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, assert } from "vitest";
+import contentType from "./index";
+
+describe("contentType", function () {
+  it("should have a default export", function () {
+    assert.strictEqual(typeof contentType, "object");
+    assert.deepEqual(Object.keys(contentType), ["format", "parse"]);
+    assert.strictEqual(typeof contentType.format, "function");
+    assert.strictEqual(typeof contentType.parse, "function");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,3 +212,5 @@ function qstring(str: string): string {
 
   throw new TypeError(`Invalid parameter value: ${str}`);
 }
+
+export default { format, parse };


### PR DESCRIPTION
The default export is now an object with two keys, "format" and "parse". This assists with upgrading from v1 to v2.