### PR TITLE
Parse up to comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The parser is lenient and does not error. You should validate `type` and `parame
 #### Options
 
 - `parameters` (default: `true`): Set to `false` to skip parameters.
+- `comma` (default: `false`): Set to `true` to stop on a comma. This can be used to parse the media range in an `Accept` header.
+- `start` (default: `0`): Set index to start parsing from.
 
 ### contentType.format(obj)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ const NullObject = /* @__PURE__ */ (() => {
  */
 export interface ContentType {
   type: string;
+  index: number;
   parameters: Record<string, string>;
 }
 
@@ -68,26 +69,46 @@ export function format(obj: Partial<ContentType>): string {
  * Options for parsing a `Content-Type` header.
  */
 export interface ParseOptions {
+  /**
+   * Exit early on the first semicolon, returning only the type.
+   * This is useful for parsing the MIME from `Content-Type` headers.
+   *
+   * @default false
+   */
   parameters?: boolean;
+  /**
+   * Exits early on a comma, returning the first value and parameters.
+   * This is useful for parsing `Accept` headers.
+   *
+   * @default false
+   */
+  comma?: boolean;
+  /**
+   * The index to start parsing from.
+   *
+   * @default 0
+   */
+  start?: number;
 }
 
 /**
  * Parse a `Content-Type` header.
  */
 export function parse(header: string, options?: ParseOptions): ContentType {
+  const stopChar = options?.comma === true ? COMMA : -1;
   const len = header.length;
-  let index = skipOWS(header, 0, len);
+  let index = skipOWS(header, options?.start ?? 0, len);
 
   const valueStart = index;
-  index = skipValue(header, index, len);
+  index = skipValue(header, index, len, stopChar);
   const valueEnd = trailingOWS(header, valueStart, index);
   const type = header.slice(valueStart, valueEnd).toLowerCase();
-  const parameters =
-    options?.parameters === false
-      ? new NullObject()
-      : parseParameters(header, index, len);
 
-  return { type, parameters };
+  if (options?.parameters === false) {
+    return { type, index, parameters: new NullObject() };
+  }
+
+  return parseParameters(header, type, index, len, stopChar);
 }
 
 const SP = 32; // " "
@@ -96,24 +117,31 @@ const SEMI = 59; // ";"
 const EQ = 61; // "="
 const DQUOTE = 34; // '"'
 const BSLASH = 92; // "\\"
+const COMMA = 44; // ","
 
 /**
  * Parses the parameters of a `Content-Type` header starting at the given index.
  */
 function parseParameters(
   header: string,
+  type: string,
   index: number,
   len: number,
-): Record<string, string> {
+  stopChar: number,
+): ContentType {
   const parameters: Record<string, string> = new NullObject();
 
   parameter: while (index < len) {
+    if (header.charCodeAt(index) === stopChar) break;
+
     index = skipOWS(header, index + 1 /* Skip over ; */, len);
 
     const keyStart = index;
 
     while (index < len) {
       const code = header.charCodeAt(index);
+      if (code === stopChar) break parameter;
+
       if (code === SEMI) continue parameter;
 
       if (code === EQ) {
@@ -129,7 +157,7 @@ function parseParameters(
           while (index < len) {
             const code = header.charCodeAt(index++);
             if (code === DQUOTE) {
-              index = skipValue(header, index, len);
+              index = skipValue(header, index, len, stopChar);
               if (parameters[key] === undefined) parameters[key] = value;
               break;
             }
@@ -146,7 +174,7 @@ function parseParameters(
         }
 
         const valueStart = index;
-        index = skipValue(header, index, len);
+        index = skipValue(header, index, len, stopChar);
 
         if (parameters[key] === undefined) {
           const valueEnd = trailingOWS(header, valueStart, index);
@@ -160,16 +188,21 @@ function parseParameters(
     }
   }
 
-  return parameters;
+  return { type, index, parameters };
 }
 
 /**
- * Skip over characters until a semicolon.
+ * Skip over characters until a semicolon or other exit character.
  */
-function skipValue(str: string, index: number, len: number): number {
+function skipValue(
+  str: string,
+  index: number,
+  len: number,
+  stopChar: number,
+): number {
   while (index < len) {
-    const char = str.charCodeAt(index);
-    if (char === SEMI) break;
+    const code = str.charCodeAt(index);
+    if (code === SEMI || code === stopChar) break;
     index++;
   }
   return index;

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export interface ParseOptions {
  * Parse a `Content-Type` header.
  */
 export function parse(header: string, options?: ParseOptions): ContentType {
-  const stopChar = options?.comma === true ? COMMA : -1;
+  const stopChar = options?.comma === true ? COMMA : 65_536; // Sentinel for "no stop char".
   const len = header.length;
   let index = skipOWS(header, options?.start ?? 0, len);
 

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -20,6 +20,7 @@ describe("parse(string)", function () {
     const type = parse("");
     assert.deepEqual(type, {
       type: "",
+      index: 0,
       parameters: {},
     });
   });
@@ -28,6 +29,7 @@ describe("parse(string)", function () {
     const type = parse("text/html");
     assert.deepEqual(type, {
       type: "text/html",
+      index: 9,
       parameters: {},
     });
   });
@@ -35,6 +37,7 @@ describe("parse(string)", function () {
   it.each(invalidTypes)("should accept invalid types: %s", function (str) {
     assert.deepEqual(parse(str), {
       type: str.trim().toLowerCase(),
+      index: str.length,
       parameters: {},
     });
   });
@@ -43,6 +46,7 @@ describe("parse(string)", function () {
     const type = parse("image/svg+xml");
     assert.deepEqual(type, {
       type: "image/svg+xml",
+      index: 13,
       parameters: {},
     });
   });
@@ -51,6 +55,7 @@ describe("parse(string)", function () {
     const type = parse(" text/html ");
     assert.deepEqual(type, {
       type: "text/html",
+      index: 11,
       parameters: {},
     });
   });
@@ -59,6 +64,7 @@ describe("parse(string)", function () {
     const type = parse("text/html; charset=utf-8; foo=bar");
     assert.deepEqual(type, {
       type: "text/html",
+      index: 33,
       parameters: {
         charset: "utf-8",
         foo: "bar",
@@ -70,6 +76,7 @@ describe("parse(string)", function () {
     const type = parse("text/html ; charset=utf-8 ; foo=bar");
     assert.deepEqual(type, {
       type: "text/html",
+      index: 35,
       parameters: {
         charset: "utf-8",
         foo: "bar",
@@ -81,6 +88,7 @@ describe("parse(string)", function () {
     const type = parse("text/html; charset=");
     assert.deepEqual(type, {
       type: "text/html",
+      index: 19,
       parameters: {
         charset: "",
       },
@@ -91,6 +99,7 @@ describe("parse(string)", function () {
     const type = parse('text/html; charset=""');
     assert.deepEqual(type, {
       type: "text/html",
+      index: 21,
       parameters: {
         charset: "",
       },
@@ -101,6 +110,7 @@ describe("parse(string)", function () {
     const type = parse("text/html; charset= ");
     assert.deepEqual(type, {
       type: "text/html",
+      index: 20,
       parameters: {
         charset: "",
       },
@@ -111,6 +121,7 @@ describe("parse(string)", function () {
     const type = parse("text/html; charset = utf-8");
     assert.deepEqual(type, {
       type: "text/html",
+      index: 26,
       parameters: {
         charset: "utf-8",
       },
@@ -121,6 +132,7 @@ describe("parse(string)", function () {
     const type = parse("IMAGE/SVG+XML");
     assert.deepEqual(type, {
       type: "image/svg+xml",
+      index: 13,
       parameters: {},
     });
   });
@@ -129,6 +141,7 @@ describe("parse(string)", function () {
     const type = parse("text/html; Charset=UTF-8");
     assert.deepEqual(type, {
       type: "text/html",
+      index: 24,
       parameters: {
         charset: "UTF-8",
       },
@@ -139,6 +152,7 @@ describe("parse(string)", function () {
     const type = parse('text/html; charset="UTF-8"');
     assert.deepEqual(type, {
       type: "text/html",
+      index: 26,
       parameters: {
         charset: "UTF-8",
       },
@@ -149,6 +163,7 @@ describe("parse(string)", function () {
     const type = parse('text/html; charset = "UT\\F-\\\\\\"8\\""');
     assert.deepEqual(type, {
       type: "text/html",
+      index: 35,
       parameters: {
         charset: 'UTF-\\"8"',
       },
@@ -161,6 +176,7 @@ describe("parse(string)", function () {
     );
     assert.deepEqual(type, {
       type: "text/html",
+      index: 54,
       parameters: {
         param: 'charset="utf-8"; foo=bar',
         bar: "foo",
@@ -172,6 +188,7 @@ describe("parse(string)", function () {
     const type = parse("text/html;;;; charset=utf-8;; foo=bar;");
     assert.deepEqual(type, {
       type: "text/html",
+      index: 38,
       parameters: {
         charset: "utf-8",
         foo: "bar",
@@ -182,6 +199,7 @@ describe("parse(string)", function () {
   it("should ignore unterminated quoted parameter", function () {
     assert.deepEqual(parse('text/plain; foo="bar'), {
       type: "text/plain",
+      index: 20,
       parameters: {},
     });
   });
@@ -189,6 +207,7 @@ describe("parse(string)", function () {
   it("should ignore unterminated quoted parameter with backslash", function () {
     assert.deepEqual(parse('text/plain; foo="bar\\'), {
       type: "text/plain",
+      index: 21,
       parameters: {},
     });
   });
@@ -196,6 +215,7 @@ describe("parse(string)", function () {
   it("should parse and ignore non-OWS after closing quote", function () {
     assert.deepEqual(parse('text/plain; foo="bar"baz'), {
       type: "text/plain",
+      index: 24,
       parameters: {
         foo: "bar",
       },
@@ -206,6 +226,7 @@ describe("parse(string)", function () {
     const type = parse('text/plain; foo="bar"baz; charset=utf-8');
     assert.deepEqual(type, {
       type: "text/plain",
+      index: 39,
       parameters: {
         foo: "bar",
         charset: "utf-8",
@@ -217,6 +238,7 @@ describe("parse(string)", function () {
     const type = parse('text/plain; foo=bar"baz');
     assert.deepEqual(type, {
       type: "text/plain",
+      index: 23,
       parameters: {
         foo: 'bar"baz',
       },
@@ -227,6 +249,7 @@ describe("parse(string)", function () {
     const type = parse("text/plain; foo=bar=baz");
     assert.deepEqual(type, {
       type: "text/plain",
+      index: 23,
       parameters: {
         foo: "bar=baz",
       },
@@ -237,6 +260,7 @@ describe("parse(string)", function () {
     const type = parse("text/html; charset=utf-8; charset=iso-8859-1");
     assert.deepEqual(type, {
       type: "text/html",
+      index: 44,
       parameters: {
         charset: "utf-8",
       },
@@ -247,6 +271,7 @@ describe("parse(string)", function () {
     const type = parse("text/html; Charset=utf-8; charset=iso-8859-1");
     assert.deepEqual(type, {
       type: "text/html",
+      index: 44,
       parameters: {
         charset: "utf-8",
       },
@@ -257,6 +282,7 @@ describe("parse(string)", function () {
     const type = parse('text/html; Charset="utf-8"; charset="iso-8859-1"');
     assert.deepEqual(type, {
       type: "text/html",
+      index: 48,
       parameters: {
         charset: "utf-8",
       },
@@ -269,6 +295,100 @@ describe("parse(string)", function () {
     });
     assert.deepEqual(type, {
       type: "text/html",
+      index: 9,
+      parameters: {},
+    });
+  });
+
+  it("should start parsing at options.start", function () {
+    const type = parse("ignored, text/html; charset=utf-8", { start: 9 });
+    assert.deepEqual(type, {
+      type: "text/html",
+      index: 33,
+      parameters: {
+        charset: "utf-8",
+      },
+    });
+  });
+
+  it("should parse successive values in an Accept header", function () {
+    const header = "text/html, application/json;q=0.9, */*;q=0.8";
+
+    assert.deepEqual(parse(header, { comma: true }), {
+      type: "text/html",
+      index: 9,
+      parameters: {},
+    });
+    assert.deepEqual(parse(header, { comma: true, start: 10 }), {
+      type: "application/json",
+      index: 33,
+      parameters: {
+        q: "0.9",
+      },
+    });
+    assert.deepEqual(parse(header, { comma: true, start: 34 }), {
+      type: "*/*",
+      index: 44,
+      parameters: {
+        q: "0.8",
+      },
+    });
+  });
+
+  it("should exit early on a comma when options.comma is true", function () {
+    const type = parse("text/html, application/json", { comma: true });
+    assert.deepEqual(type, {
+      type: "text/html",
+      index: 9,
+      parameters: {},
+    });
+  });
+
+  it("should exit early after parameters when options.comma is true", function () {
+    const type = parse(
+      "text/html; charset=utf-8, application/json; charset=utf-16",
+      { comma: true },
+    );
+    assert.deepEqual(type, {
+      type: "text/html",
+      index: 24,
+      parameters: {
+        charset: "utf-8",
+      },
+    });
+  });
+
+  it("should exit early after an invalid parameter when options.comma is true", function () {
+    const type = parse("text/html; invalid, application/json", {
+      comma: true,
+    });
+    assert.deepEqual(type, {
+      type: "text/html",
+      index: 18,
+      parameters: {},
+    });
+  });
+
+  it("should not exit on a comma inside quotes", function () {
+    const type = parse(
+      'text/html; profile="compact,print"; charset=utf-8, application/json',
+      { comma: true },
+    );
+    assert.deepEqual(type, {
+      type: "text/html",
+      index: 49,
+      parameters: {
+        profile: "compact,print",
+        charset: "utf-8",
+      },
+    });
+  });
+
+  it("should preserve commas by default", function () {
+    const type = parse("text/html, application/json");
+    assert.deepEqual(type, {
+      type: "text/html, application/json",
+      index: 27,
       parameters: {},
     });
   });


### PR DESCRIPTION
Adding support for exiting on a `,`. Useful for parsing an accepts header. This _could_ be part of another package but I think it'd be useful to keep potential `Accept` header parsing and the `Content-Type` parser aligned on behavior.

It may also be useful for https://github.com/jshttp/content-type/issues/29.